### PR TITLE
implement mmap dynamic growth + cleanup.

### DIFF
--- a/blockstore.go
+++ b/blockstore.go
@@ -3,27 +3,63 @@ package lmdbbs
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
+	"sync"
 	"sync/atomic"
 
-	"github.com/bmatsuo/lmdb-go/lmdb"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/ledgerwatch/lmdb-go/lmdb"
+	"github.com/pkg/errors"
 )
 
-const (
-	MaxDBs        = 1       // needs to be configurable.
-	MapSize       = 1 << 38 // 256GiB, this will need to be configurable.
-	MaxReaders    = 128
-	FreelistReuse = uint(1000) // pages, in case we decide to use https://github.com/ledgerwatch/lmdb-go (non-viral license).
+var (
+	// DefaultInitialMmapSize is the default initial mmap size to be used if the
+	// supplied value is zero or invalid. Unless modified, this value is 16MiB.
+	DefaultInitialMmapSize = int64(16 << 20) // 16MiB.
+
+	// DefaultMmapGrowthStepFactor is the default mmap growth step factor to be
+	// used if the supplied value is zero or invalid. Unless modified, this
+	// value is 2, which doubles the mmap every time we encounter an
+	// MDB_MAP_FULL error.
+	DefaultMmapGrowthStepFactor = float64(2) // double the mmap size every time.
+
+	// DefaultMmapGrowthStepMax is the default mmap growth maximum step to be
+	// used if the supplied value is zero or invalid. Unless modified, this
+	// value is 4GiB.
+	DefaultMmapGrowthStepMax = int64(4 << 30) // maximum step size is 4GiB at a time.
 )
+
+var log = logging.Logger("lmdbbs")
 
 type Blockstore struct {
-	env *lmdb.Env
-	db  lmdb.DBI
+	// oplock is a two-tier concurrent/exclusive lock to synchronize mmap
+	// growth operations. The concurrent tier is used by blockstore operations,
+	// and the exclusive lock is acquired by the mmap grow operation.
+	oplock sync.RWMutex
 
-	closed int32
+	// cursors.
+	cursorlock sync.Mutex
+	cursors    []*cursor
+
+	// dedupGrow deduplicates concurrent calls to grow(); it is recycled every
+	// time that grow() actually runs.
+	dedupGrow *sync.Once
+
+	// env represents a database environment. An lmdb env can contain multiple
+	// databases, all residing in the same shared memory map, but the blockstore
+	// only uses a 1:1 mapping between envs and dbs.
+	env *lmdb.Env
+	// db is an object representing an LMDB database inside an env.
+	db lmdb.DBI
+	// opts are the options for this blockstore.
+	opts *Options
+
+	pagesize int64 // the memory page size reported by the OS.
+	closed   int32
 }
 
 var (
@@ -31,93 +67,244 @@ var (
 	_ blockstore.Viewer     = (*Blockstore)(nil)
 )
 
-func Open(path string) (*Blockstore, error) {
+type Options struct {
+	// Path is the directory where the LMDB blockstore resides. If it doesn't
+	// exist, it will be created.
+	Path string
+
+	// ReadOnly, if true, opens this blockstore in read-only mode.
+	ReadOnly bool
+
+	// NoSync disables flushing system buffers to disk immediately when
+	// committing transactions.
+	NoSync bool
+
+	// +++ DB sizing fields. +++ //
+	// InitialMmapSize is the initial mmap size passed to LMDB when
+	// creating/opening the environment.
+	InitialMmapSize int64
+
+	// MmapGrowthStepFactor determines the next map size when a write fails. The
+	// current size is multiplied by the factor, and rounded up to the next
+	// value divisible by os.Getpagesize(), to obtain the new map size, which is
+	// applied with mdb_env_set_mapsize.
+	MmapGrowthStepFactor float64
+
+	// MmapGrowthStepMax is the maximum step size by which we'll grow the mmap.
+	MmapGrowthStepMax int64
+	// --- DB sizing fields. --- //
+
+	// MaxReaders is the maximum amount of concurrent reader slots that exist
+	// in the lock table.
+	MaxReaders int
+}
+
+func Open(opts *Options) (*Blockstore, error) {
+	path := opts.Path
+	switch st, err := os.Stat(path); {
+	case os.IsNotExist(err):
+		if err := os.MkdirAll(path, 0777); err != nil {
+			return nil, fmt.Errorf("failed to create lmdb data directory at %s: %w", path, err)
+		}
+	case err != nil:
+		return nil, fmt.Errorf("failed to check if lmdb data dir exists: %w", err)
+	case !st.IsDir():
+		return nil, fmt.Errorf("lmdb path is not a directory %s", path)
+	}
+
+	pagesize := os.Getpagesize()
+	if pagesize < 0 {
+		pagesize = 4096 // being defensive and setting a safe value (4KiB).
+	}
+
+	// Validate mmap sizing parameters.
+	//
+	// InitialMmapSize cannot be negative nor zero, and must be rounded up to a multiple of the OS page size.
+	if v := opts.InitialMmapSize; v <= 0 {
+		log.Warnf("initial mmap size (%d) cannot be negative or zero; falling back to default: %d", v, DefaultInitialMmapSize)
+		opts.InitialMmapSize = DefaultInitialMmapSize
+	}
+	if v := roundup(opts.InitialMmapSize, int64(pagesize)); v != opts.InitialMmapSize {
+		log.Warnf("initial mmap size (%d) must be a multiple of the OS pagesize (%d); rounding up: %d", opts.InitialMmapSize, pagesize, v)
+		opts.InitialMmapSize = v
+	}
+
+	// MmapGrowthStepMax cannot be negative nor zero, and must be rounded up to a multiple of the OS page size.
+	if v := opts.MmapGrowthStepMax; v <= 0 {
+		log.Warnf("maximum mmap growth step (%d) cannot be negative or zero; falling back to default: %d", v, DefaultMmapGrowthStepMax)
+		opts.MmapGrowthStepMax = DefaultMmapGrowthStepMax
+	}
+	if v := roundup(opts.MmapGrowthStepMax, int64(pagesize)); v != opts.MmapGrowthStepMax {
+		log.Warnf("maximum mmap growth step (%d) must be a multiple of the OS pagesize (%d); rounding up: %d", opts.MmapGrowthStepMax, pagesize, v)
+		opts.MmapGrowthStepMax = v
+	}
+
+	if v := opts.MmapGrowthStepFactor; v <= 1 {
+		log.Warnf("mmap growth step factor (%f) cannot be lower or equal to 1; falling back to default: %f", v, DefaultMmapGrowthStepFactor)
+		opts.MmapGrowthStepFactor = DefaultMmapGrowthStepFactor
+	}
+
+	// Create an LMDB environment. We set the initial mapsize, but do not set
+	// max DBs, since a blockstore only requires a single, unnamed LMDB DB.
+	// see: http://www.lmdb.tech/doc/group__mdb.html#gaa2fc2f1f37cb1115e733b62cab2fcdbc
 	env, err := lmdb.NewEnv()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize LMDB env: %w", err)
 	}
-	if err = env.SetMapSize(MapSize); err != nil {
+	if err = env.SetMapSize(opts.InitialMmapSize); err != nil {
 		return nil, fmt.Errorf("failed to set LMDB map size: %w", err)
 	}
-	if err = env.SetMaxDBs(MaxDBs); err != nil {
-		return nil, fmt.Errorf("failed to set LMDB max dbs: %w", err)
-	}
-	if err = env.SetMaxReaders(MaxReaders); err != nil {
-		return nil, fmt.Errorf("failed to set LMDB max readers: %w", err)
-	}
-
-	if st, err := os.Stat(path); os.IsNotExist(err) {
-		if err := os.MkdirAll(path, 0777); err != nil {
-			return nil, fmt.Errorf("failed to create lmdb data directory at %s: %w", path, err)
+	// Use the default max readers (126) unless a value is passed in the options.
+	if opts.MaxReaders != 0 {
+		if err = env.SetMaxReaders(opts.MaxReaders); err != nil {
+			return nil, fmt.Errorf("failed to set LMDB max readers: %w", err)
 		}
-	} else if err != nil {
-		return nil, fmt.Errorf("failed to check if lmdb data dir exists: %w", err)
-	} else if !st.IsDir() {
-		return nil, fmt.Errorf("lmdb path is not a directory %s", path)
 	}
 
-	err = env.Open(path, lmdb.NoSync|lmdb.WriteMap|lmdb.MapAsync|lmdb.NoReadahead, 0777)
+	// Environment options:
+	// --------------------
+	//
+	// - MDB_FIXEDMAP: Use a fixed address for the mmap region. This flag must be specified when creating the environment,
+	//   and is stored persistently in the environment. If successful, the memory map will always reside at the same
+	//   virtual address and pointers used to reference data items in the database will be constant across multiple
+	//   invocations. This option may not always work, depending on how the operating system has allocated memory to
+	//   shared libraries and other uses. The feature is highly experimental.
+	// - MDB_NOSUBDIR: By default, LMDB creates its environment in a directory whose pathname is given in path, and
+	//   creates its data and lock files under that directory. With this option, path is used as-is for the database
+	//   main data file. The database lock file is the path with "-lock" appended.
+	// - MDB_RDONLY: Open the environment in read-only mode. No write operations will be allowed. LMDB will still
+	//   modify the lock file - except on read-only filesystems, where LMDB does not use locks.
+	// - MDB_WRITEMAP: Use a writeable memory map unless MDB_RDONLY is set. This is faster and uses fewer mallocs,
+	//   but loses protection from application bugs like wild pointer writes and other bad updates into the database.
+	//   Incompatible with nested transactions. Do not mix processes with and without MDB_WRITEMAP on the same
+	//   environment. This can defeat durability (mdb_env_sync etc).
+	// - MDB_NOMETASYNC: Flush system buffers to disk only once per transaction, omit the metadata flush. Defer that
+	//   until the system flushes files to disk, or next non-MDB_RDONLY commit or mdb_env_sync(). This optimization
+	//   maintains database integrity, but a system crash may undo the last committed transaction. I.e. it preserves
+	//   the ACI (atomicity, consistency, isolation) but not D (durability) database property. This flag may be changed
+	//   at any time using mdb_env_set_flags().
+	// - MDB_NOSYNC: Don't flush system buffers to disk when committing a transaction. This optimization means a system
+	//   crash can corrupt the database or lose the last transactions if buffers are not yet flushed to disk. The risk
+	//   is governed by how often the system flushes dirty buffers to disk and how often mdb_env_sync() is called.
+	//   However, if the filesystem preserves write order and the MDB_WRITEMAP flag is not used, transactions exhibit
+	//   ACI (atomicity, consistency, isolation) properties and only lose D (durability). i.e. database integrity is
+	//   maintained, but a system crash may undo the final transactions. Note that (MDB_NOSYNC | MDB_WRITEMAP) leaves
+	//   the system with no hint for when to write transactions to disk, unless mdb_env_sync() is called.
+	//   (MDB_MAPASYNC | MDB_WRITEMAP) may be preferable. This flag may be changed at any time using
+	//   mdb_env_set_flags().
+	// - MDB_MAPASYNC: When using MDB_WRITEMAP, use asynchronous flushes to disk. As with MDB_NOSYNC, a system crash
+	//   can then corrupt the database or lose the last transactions. Calling mdb_env_sync() ensures on-disk database
+	//   integrity until next commit. This flag may be changed at any time using mdb_env_set_flags().
+	// - MDB_NOTLS: Don't use Thread-Local Storage. Tie reader locktable slots to MDB_txn objects instead of to threads.
+	//   i.e. mdb_txn_reset() keeps the slot reseved for the MDB_txn object. A thread may use parallel read-only
+	//   transactions. A read-only transaction may span threads if the user synchronizes its use. Applications that
+	//   multiplex many user threads over individual OS threads need this option. Such an application must also
+	//   serialize the write transactions in an OS thread, since LMDB's write locking is unaware of the user threads.
+	// - MDB_NOLOCK: Don't do any locking. If concurrent access is anticipated, the caller must manage all concurrency
+	//   itself. For proper operation the caller must enforce single-writer semantics, and must ensure that no readers
+	//   are using old transactions while a writer is active. The simplest approach is to use an exclusive lock so that
+	//   no readers may be active at all when a writer begins.
+	// - MDB_NORDAHEAD: Turn off readahead. Most operating systems perform readahead on read requests by default. This
+	//   option turns it off if the OS supports it. Turning it off may help random read performance when the DB is
+	//   larger than RAM and system RAM is full. The option is not implemented on Windows.
+	// - MDB_NOMEMINIT: Don't initialize malloc'd memory before writing to unused spaces in the data file. By default,
+	//   memory for pages written to the data file is obtained using malloc. While these pages may be reused in
+	//   subsequent transactions, freshly malloc'd pages will be initialized to zeroes before use. This avoids
+	//   persisting leftover data from other code (that used the heap and subsequently freed the memory) into the data
+	//   file. Note that many other system libraries may allocate and free memory from the heap for arbitrary uses.
+	//   e.g., stdio may use the heap for file I/O buffers. This initialization step has a modest performance cost so
+	//   some applications may want to disable it using this flag. This option can be a problem for applications which
+	//   handle sensitive data like passwords, and it makes memory checkers like Valgrind noisy. This flag is not needed
+	//   with MDB_WRITEMAP, which writes directly to the mmap instead of using malloc for pages. The initialization is
+	//   also skipped if MDB_RESERVE is used; the caller is expected to overwrite all of the memory that was reserved
+	//   in that case. This flag may be changed at any time using mdb_env_set_flags().
+	//
+	// Source: http://www.lmdb.tech/doc/group__mdb.html#ga32a193c6bf4d7d5c5d579e71f22e9340
+
+	// Maybe consider NoTLS tradeoffs.
+	// https://twitter.com/yrashk/status/838621043480748036
+	// https://github.com/PumpkinDB/PumpkinDB/pull/178
+	var flags uint = lmdb.NoReadahead | lmdb.WriteMap
+	if opts.ReadOnly {
+		flags |= lmdb.Readonly
+	}
+	if opts.NoSync {
+		flags |= lmdb.MapAsync
+	}
+	err = env.Open(path, flags, 0777)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open lmdb database: %w", err)
 	}
 
-	bs := new(Blockstore)
-	bs.env = env
+	bs := &Blockstore{
+		env:       env,
+		opts:      opts,
+		dedupGrow: new(sync.Once),
+		pagesize:  int64(pagesize),
+	}
 	err = env.Update(func(txn *lmdb.Txn) (err error) {
-		bs.db, err = txn.CreateDBI("blocks")
+		bs.db, err = txn.OpenRoot(lmdb.Create)
 		return err
 	})
+	if err != nil {
+		_ = env.Close()
+		return nil, fmt.Errorf("failed to create/open lmdb database: %w", err)
+	}
 	return bs, err
 }
 
 func (b *Blockstore) Close() error {
-	// lmdb doesn't do close idempotency, so we only process a single
-	// call to Close.
-	if atomic.CompareAndSwapInt32(&b.closed, 0, 1) {
-		b.env.CloseDBI(b.db)
-		return b.env.Close()
+	if !atomic.CompareAndSwapInt32(&b.closed, 0, 1) {
+		return nil
 	}
-	return nil
+	b.env.CloseDBI(b.db)
+	return b.env.Close()
 }
 
 func (b *Blockstore) Has(cid cid.Cid) (bool, error) {
-	var exists bool
+	b.oplock.RLock()
+	defer b.oplock.RUnlock()
+
 	err := b.env.View(func(txn *lmdb.Txn) error {
 		txn.RawRead = true
 		_, err := txn.Get(b.db, cid.Hash())
-		if err == nil {
-			exists = true
-		}
 		return err
 	})
-	if lmdb.IsNotFound(err) {
-		return exists, nil
+	switch {
+	case err == nil:
+		return true, nil
+	case lmdb.IsNotFound(err):
+		return false, nil
 	}
-	return exists, err
+	return false, err
 }
 
 func (b *Blockstore) Get(cid cid.Cid) (blocks.Block, error) {
+	b.oplock.RLock()
+	defer b.oplock.RUnlock()
+
 	var val []byte
 	err := b.env.View(func(txn *lmdb.Txn) error {
-		txn.RawRead = true
 		v, err := txn.Get(b.db, cid.Hash())
 		if err == nil {
-			val = make([]byte, len(v))
-			copy(val, v)
+			val = v
 		}
 		return err
 	})
-	if err == nil {
+	switch {
+	case err == nil:
 		return blocks.NewBlockWithCid(val, cid)
-	}
-	// lmdb returns badvalsize with nil keys.
-	if lmdb.IsNotFound(err) || lmdb.IsErrno(err, lmdb.BadValSize) {
-		return nil, blockstore.ErrNotFound
+	case lmdb.IsNotFound(err) || lmdb.IsErrno(err, lmdb.BadValSize):
+		// lmdb returns badvalsize with nil keys.
+		err = blockstore.ErrNotFound
 	}
 	return nil, err
 }
 
 func (b *Blockstore) View(cid cid.Cid, callback func([]byte) error) error {
+	b.oplock.RLock()
+	defer b.oplock.RUnlock()
+
 	err := b.env.View(func(txn *lmdb.Txn) error {
 		txn.RawRead = true
 		v, err := txn.Get(b.db, cid.Hash())
@@ -126,14 +313,20 @@ func (b *Blockstore) View(cid cid.Cid, callback func([]byte) error) error {
 		}
 		return err
 	})
-	// lmdb returns badvalsize with nil keys.
-	if lmdb.IsNotFound(err) || lmdb.IsErrno(err, lmdb.BadValSize) {
-		return blockstore.ErrNotFound
+	switch {
+	case err == nil:
+		return nil // shortcircuit the happy path with no comparisons.
+	case lmdb.IsNotFound(err) || lmdb.IsErrno(err, lmdb.BadValSize):
+		// lmdb returns badvalsize with nil keys.
+		err = blockstore.ErrNotFound
 	}
 	return err
 }
 
 func (b *Blockstore) GetSize(cid cid.Cid) (int, error) {
+	b.oplock.RLock()
+	defer b.oplock.RUnlock()
+
 	size := -1
 	err := b.env.View(func(txn *lmdb.Txn) error {
 		txn.RawRead = true
@@ -143,24 +336,47 @@ func (b *Blockstore) GetSize(cid cid.Cid) (int, error) {
 		}
 		return err
 	})
-	if lmdb.IsNotFound(err) {
+	switch {
+	case err == nil:
+		return size, nil // shortcircuit the happy path with no comparisons.
+	case lmdb.IsNotFound(err) || lmdb.IsErrno(err, lmdb.BadValSize):
 		err = blockstore.ErrNotFound
 	}
 	return size, err
 }
 
 func (b *Blockstore) Put(block blocks.Block) error {
-	return b.env.Update(func(txn *lmdb.Txn) error {
+	b.oplock.RLock()
+	defer b.oplock.RUnlock()
+
+Retry:
+	err := b.env.Update(func(txn *lmdb.Txn) error {
 		err := txn.Put(b.db, block.Cid().Hash(), block.RawData(), lmdb.NoOverwrite)
 		if err == nil || lmdb.IsErrno(err, lmdb.KeyExist) {
 			return nil
 		}
 		return err
 	})
+	if lmdb.IsMapFull(err) {
+		o := b.dedupGrow   // take the deduplicator under the lock.
+		b.oplock.RUnlock() // drop the concurrent lock.
+		var err error
+		o.Do(func() { err = b.grow() })
+		if err != nil {
+			return fmt.Errorf("lmbd put failed: %w", err)
+		}
+		b.oplock.RLock() // reclaim the concurrent lock.
+		goto Retry
+	}
+	return err
 }
 
 func (b *Blockstore) PutMany(blocks []blocks.Block) error {
-	return b.env.Update(func(txn *lmdb.Txn) error {
+	b.oplock.RLock()
+	defer b.oplock.RUnlock()
+
+Retry:
+	err := b.env.Update(func(txn *lmdb.Txn) error {
 		for _, block := range blocks {
 			err := txn.Put(b.db, block.Cid().Hash(), block.RawData(), lmdb.NoOverwrite)
 			if err != nil && !lmdb.IsErrno(err, lmdb.KeyExist) {
@@ -170,50 +386,219 @@ func (b *Blockstore) PutMany(blocks []blocks.Block) error {
 		}
 		return nil
 	})
-}
-
-func (b *Blockstore) DeleteBlock(cid cid.Cid) error {
-	err := b.env.Update(func(txn *lmdb.Txn) error {
-		return txn.Del(b.db, cid.Hash(), nil)
-	})
-	if lmdb.IsNotFound(err) {
-		err = nil
+	if lmdb.IsMapFull(err) {
+		o := b.dedupGrow   // take the deduplicator under the lock.
+		b.oplock.RUnlock() // drop the concurrent lock.
+		var err error
+		o.Do(func() { err = b.grow() })
+		if err != nil {
+			return fmt.Errorf("lmbd put many failed: %w", err)
+		}
+		b.oplock.RLock() // reclaim the concurrent lock.
+		goto Retry
 	}
 	return err
 }
 
-func (b *Blockstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
-	ch := make(chan cid.Cid)
-	go func() {
-		_ = b.env.View(func(txn *lmdb.Txn) error {
-			defer close(ch)
+func (b *Blockstore) DeleteBlock(cid cid.Cid) error {
+	b.oplock.RLock()
+	defer b.oplock.RUnlock()
 
-			txn.RawRead = true
-			cur, err := txn.OpenCursor(b.db)
+Retry:
+	err := b.env.Update(func(txn *lmdb.Txn) error {
+		return txn.Del(b.db, cid.Hash(), nil)
+	})
+	if lmdb.IsNotFound(err) {
+		return nil
+	}
+	if lmdb.IsMapFull(err) {
+		o := b.dedupGrow   // take the deduplicator under the lock.
+		b.oplock.RUnlock() // drop the concurrent lock.
+		var err error
+		o.Do(func() { err = b.grow() })
+		if err != nil {
+			return fmt.Errorf("lmbd delete failed: %w", err)
+		}
+		b.oplock.RLock() // reclaim the concurrent lock.
+		goto Retry
+	}
+	return err
+}
+
+type cursor struct {
+	ctx context.Context
+	b   *Blockstore
+
+	last        cid.Cid
+	outCh       chan cid.Cid
+	interruptCh chan chan struct{}
+
+	runlk  sync.Mutex
+	doneCh chan struct{}
+}
+
+var errInterrupted = errors.New("interrupted")
+
+// interrupt interrupts a cursor, and waits until the cursor is interrupted.
+func (c *cursor) interrupt() {
+	ch := make(chan struct{})
+	select {
+	case c.interruptCh <- ch:
+		<-ch
+	case <-c.doneCh:
+		// this cursor is already done and is no longer listening for
+		// interrupt signals.
+	}
+}
+
+// run runs this cursor
+func (c *cursor) run() {
+	c.runlk.Lock()
+	defer c.runlk.Unlock()
+
+	select {
+	case <-c.doneCh:
+		return // already done.
+	default:
+	}
+
+	var notifyClosed chan struct{}
+	err := c.b.env.View(func(txn *lmdb.Txn) error {
+		txn.RawRead = true
+		cur, err := txn.OpenCursor(c.b.db)
+		if err != nil {
+			return err
+		}
+		defer cur.Close()
+
+		if c.last.Defined() {
+			_, _, err := cur.Get(c.last.Hash(), nil, lmdb.Set)
+			if err != nil {
+				return fmt.Errorf("failed to position cursor: %w", err)
+			}
+		}
+
+		for c.ctx.Err() == nil { // context has fired.
+			// yield if an interrupt has been requested.
+			select {
+			case notifyClosed = <-c.interruptCh:
+				return errInterrupted
+			default:
+			}
+
+			k, _, err := cur.Get(nil, nil, lmdb.Next)
+			if lmdb.IsNotFound(err) {
+				return nil
+			}
 			if err != nil {
 				return err
 			}
-			defer cur.Close()
 
-			for {
-				if ctx.Err() != nil {
-					return nil // context has fired.
-				}
-				k, _, err := cur.Get(nil, nil, lmdb.Next)
-				if lmdb.IsNotFound(err) {
-					return nil
-				}
-				if err != nil {
-					return err
-				}
-				ch <- cid.NewCidV1(cid.Raw, k)
+			it := cid.NewCidV1(cid.Raw, k) // makes a copy of k
+			select {
+			case c.outCh <- it:
+			case notifyClosed = <-c.interruptCh:
+				return errInterrupted
 			}
-		})
-	}()
+			c.last = it
+		}
+		return nil
+	})
+
+	if err == errInterrupted {
+		close(notifyClosed)
+		return
+	}
+
+	// this cursor is finished, either in success or in error.
+	close(c.doneCh)
+	close(c.outCh)
+	c.b.cursorlock.Lock()
+	for i, other := range c.b.cursors {
+		if other == c {
+			c.b.cursors = append(c.b.cursors[:i], c.b.cursors[i+1:]...)
+			break
+		}
+	}
+	c.b.cursorlock.Unlock()
+}
+
+// AllKeysChan starts a cursor to return all keys from the underlying
+// MDB store. The cursor could be preempted at any time by a mmap grow
+// operation. When that happens, the cursor yields, and the grow operation
+// resumes it after the mmap expansion is completed.
+//
+// Consistency is not guaranteed. That is, keys returned are not a snapshot
+// taken when this method is called. The set of returned keys will vary with
+// concurrent writes.
+func (b *Blockstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
+	ch := make(chan cid.Cid)
+
+	b.cursorlock.Lock()
+	defer b.cursorlock.Unlock()
+
+	c := &cursor{
+		ctx:         ctx,
+		b:           b,
+		outCh:       ch,
+		interruptCh: make(chan chan struct{}),
+		doneCh:      make(chan struct{}),
+	}
+
+	b.cursors = append(b.cursors, c)
+
+	go c.run()
 
 	return ch, nil
 }
 
 func (b *Blockstore) HashOnRead(_ bool) {
 	// not supported
+}
+
+func (b *Blockstore) grow() error {
+	b.oplock.Lock() // acquire the exclusive lock.
+	defer b.oplock.Unlock()
+
+	b.cursorlock.Lock()
+	defer b.cursorlock.Unlock()
+
+	b.dedupGrow = new(sync.Once) // recycle the sync.Once.
+
+	// interrupt all cursors.
+	for _, c := range b.cursors {
+		c.interrupt() // will wait until the transaction finishes.
+	}
+
+	prev, err := b.env.Info()
+	if err != nil {
+		return fmt.Errorf("failed to obtain env info to grow lmdb mmap: %w", err)
+	}
+
+	// Calculate the next size using the growth step factor; round to a multiple
+	// of pagesize. If the proposed growth is larger than the maximum allowable
+	// step, reset to the current size + max step.
+	nextSize := int64(math.Ceil(float64(prev.MapSize) * b.opts.MmapGrowthStepFactor))
+	nextSize = roundup(nextSize, b.pagesize) // round to a pagesize multiple.
+	if nextSize > prev.MapSize+b.opts.MmapGrowthStepMax {
+		nextSize = prev.MapSize + b.opts.MmapGrowthStepMax
+	}
+	if err := b.env.SetMapSize(nextSize); err != nil {
+		return fmt.Errorf("failed to grow the mmap: %w", err)
+	}
+	next, err := b.env.Info()
+	if err != nil {
+		return fmt.Errorf("failed to obtain env info after growing lmdb mmap: %w", err)
+	}
+	log.Infof("grew lmdb mmap: %d => %d", prev.MapSize, next.MapSize)
+
+	// resume all cursors.
+	for _, c := range b.cursors {
+		go c.run()
+	}
+	return nil
+}
+
+func roundup(value, multiple int64) int64 {
+	return int64(math.Ceil(float64(value)/float64(multiple))) * multiple
 }

--- a/blockstore.go
+++ b/blockstore.go
@@ -18,14 +18,14 @@ import (
 
 var (
 	// DefaultInitialMmapSize is the default initial mmap size to be used if the
-	// supplied value is zero or invalid. Unless modified, this value is 16MiB.
-	DefaultInitialMmapSize = int64(16 << 20) // 16MiB.
+	// supplied value is zero or invalid. Unless modified, this value is 1GiB.
+	DefaultInitialMmapSize = int64(1 << 30) // 1GiB.
 
 	// DefaultMmapGrowthStepFactor is the default mmap growth step factor to be
 	// used if the supplied value is zero or invalid. Unless modified, this
-	// value is 2, which doubles the mmap every time we encounter an
-	// MDB_MAP_FULL error.
-	DefaultMmapGrowthStepFactor = float64(2) // double the mmap size every time.
+	// value is 1.5, which multiplies the mmap size by 1.5 every time we
+	// encounter an MDB_MAP_FULL error.
+	DefaultMmapGrowthStepFactor = 1.5 // 1.5x the mmap every time.
 
 	// DefaultMmapGrowthStepMax is the default mmap growth maximum step to be
 	// used if the supplied value is zero or invalid. Unless modified, this
@@ -121,7 +121,7 @@ func Open(opts *Options) (*Blockstore, error) {
 	//
 	// InitialMmapSize cannot be negative nor zero, and must be rounded up to a multiple of the OS page size.
 	if v := opts.InitialMmapSize; v <= 0 {
-		log.Warnf("initial mmap size (%d) cannot be negative or zero; falling back to default: %d", v, DefaultInitialMmapSize)
+		log.Debugf("using default initial mmap size: %d", DefaultInitialMmapSize)
 		opts.InitialMmapSize = DefaultInitialMmapSize
 	}
 	if v := roundup(opts.InitialMmapSize, int64(pagesize)); v != opts.InitialMmapSize {
@@ -131,7 +131,7 @@ func Open(opts *Options) (*Blockstore, error) {
 
 	// MmapGrowthStepMax cannot be negative nor zero, and must be rounded up to a multiple of the OS page size.
 	if v := opts.MmapGrowthStepMax; v <= 0 {
-		log.Warnf("maximum mmap growth step (%d) cannot be negative or zero; falling back to default: %d", v, DefaultMmapGrowthStepMax)
+		log.Debugf("using default max mmap growth step: %d", DefaultMmapGrowthStepMax)
 		opts.MmapGrowthStepMax = DefaultMmapGrowthStepMax
 	}
 	if v := roundup(opts.MmapGrowthStepMax, int64(pagesize)); v != opts.MmapGrowthStepMax {
@@ -140,7 +140,7 @@ func Open(opts *Options) (*Blockstore, error) {
 	}
 
 	if v := opts.MmapGrowthStepFactor; v <= 1 {
-		log.Warnf("mmap growth step factor (%f) cannot be lower or equal to 1; falling back to default: %f", v, DefaultMmapGrowthStepFactor)
+		log.Debugf("using default mmap growth step factor: %f", DefaultMmapGrowthStepFactor)
 		opts.MmapGrowthStepFactor = DefaultMmapGrowthStepFactor
 	}
 

--- a/blockstore_test.go
+++ b/blockstore_test.go
@@ -1,41 +1,243 @@
 package lmdbbs
 
 import (
+	"context"
+	"fmt"
+	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
+	"sync"
 	"testing"
 
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	logger "github.com/ipfs/go-log/v2"
+	"github.com/multiformats/go-multihash"
 	bstest "github.com/raulk/go-bs-tests"
+	"github.com/stretchr/testify/require"
 )
 
+func init() {
+	logger.SetupLogging(logger.Config{Stdout: true})
+}
+
 func TestLMDBBlockstore(t *testing.T) {
+	sync := Options{NoSync: false}
 	s := &bstest.Suite{
-		NewBlockstore:  newBlockstore,
-		OpenBlockstore: openBlockstore,
+		NewBlockstore:  newBlockstore(sync),
+		OpenBlockstore: openBlockstore(sync),
 	}
-	s.RunTests(t, "")
+	s.RunTests(t, "sync")
+
+	nosync := Options{NoSync: true}
+	s = &bstest.Suite{
+		NewBlockstore:  newBlockstore(nosync),
+		OpenBlockstore: openBlockstore(nosync),
+	}
+	s.RunTests(t, "nosync")
 }
 
-func newBlockstore(tb testing.TB) (bstest.Blockstore, string) {
-	tb.Helper()
+func newBlockstore(opts Options) func(tb testing.TB) (bstest.Blockstore, string) {
+	return func(tb testing.TB) (bstest.Blockstore, string) {
+		tb.Helper()
 
-	path, err := ioutil.TempDir("", "")
-	if err != nil {
-		tb.Fatal(err)
+		path, err := ioutil.TempDir("", "")
+		if err != nil {
+			tb.Fatal(err)
+		}
+
+		opts.Path = path
+		db, err := Open(&opts)
+		if err != nil {
+			tb.Fatal(err)
+		}
+
+		tb.Cleanup(func() {
+			_ = os.RemoveAll(path)
+		})
+
+		return db, path
 	}
-
-	db, err := Open(path)
-	if err != nil {
-		tb.Fatal(err)
-	}
-
-	tb.Cleanup(func() {
-		_ = os.RemoveAll(path)
-	})
-
-	return db, path
 }
 
-func openBlockstore(tb testing.TB, path string) (bstest.Blockstore, error) {
-	return Open(path)
+func openBlockstore(opts Options) func(tb testing.TB, path string) (bstest.Blockstore, error) {
+	return func(tb testing.TB, path string) (bstest.Blockstore, error) {
+		opts.Path = path
+		return Open(&opts)
+	}
+}
+
+func TestMmapExpansionSucceedsReopen(t *testing.T) {
+	opts := Options{InitialMmapSize: 1 << 20} // 1MiB.
+
+	bs, path := newBlockstore(opts)(t)
+
+	info, err := bs.(*Blockstore).env.Info()
+	require.NoError(t, err)
+	prev := info.MapSize
+
+	putEntries(t, bs, 16*1024, 1*1024)
+
+	info, err = bs.(*Blockstore).env.Info()
+	require.NoError(t, err)
+	current := info.MapSize
+	require.Greater(t, current, prev)
+
+	// close the db.
+	require.NoError(t, bs.(io.Closer).Close())
+
+	// reopen the database with the original initial mmap size.
+	bs, err = openBlockstore(opts)(t, path)
+	require.NoError(t, err)
+
+	info, err = bs.(*Blockstore).env.Info()
+	require.NoError(t, err)
+	reopened := info.MapSize
+	require.EqualValues(t, 34185216, reopened) // this is the exact database size.
+
+	// verify that we can add more entries, and that we grow again.
+	putEntries(t, bs, 16*1024, 1*1024)
+	info, err = bs.(*Blockstore).env.Info()
+	require.NoError(t, err)
+	final := info.MapSize
+	require.Greater(t, final, reopened)
+}
+
+func TestNoMmapExpansion(t *testing.T) {
+	opts := Options{InitialMmapSize: 64 << 20} // 64MiB, a large enough mmap size.
+
+	bs, _ := newBlockstore(opts)(t)
+	defer bs.(io.Closer).Close()
+
+	info, err := bs.(*Blockstore).env.Info()
+	require.NoError(t, err)
+	prev := info.MapSize
+
+	putEntries(t, bs, 16*1024, 1*1024)
+
+	info, err = bs.(*Blockstore).env.Info()
+	require.NoError(t, err)
+	current := info.MapSize
+	require.EqualValues(t, prev, current)
+}
+
+func TestMmapExpansionWithCursors(t *testing.T) {
+	opts := Options{InitialMmapSize: 64 << 20} // 64MiB, a large enough mmap size.
+
+	bs, _ := newBlockstore(opts)(t)
+	defer bs.(io.Closer).Close()
+
+	putEntries(t, bs, 1*1024, 1*1024)
+
+	// cursor 1.
+	ctx, cancel := context.WithCancel(context.Background())
+	ch1, err := bs.AllKeysChan(ctx)
+	require.NoError(t, err)
+	<-ch1 // consume one entry
+
+	// cursor 2.
+	ch2, err := bs.AllKeysChan(ctx)
+	require.NoError(t, err)
+	<-ch2 // consume one entry
+
+	// cursor 3.
+	ch3, err := bs.AllKeysChan(ctx)
+	require.NoError(t, err)
+	<-ch3 // consume one entry
+
+	// add more entries to force the mmap to grow.
+	putEntries(t, bs, 4*1024, 1*1024)
+
+	var i int
+	for range ch1 {
+		i++ // verify that the cursor continues running and eventually finishes.
+	}
+	require.Greater(t, i, 1*1024) // we see entries from the second insertion batch.
+
+	i = 0
+	for range ch2 {
+		i++ // verify that the cursor continues running and eventually finishes.
+	}
+	require.Greater(t, i, 1*1024) // we see entries from the second insertion batch.
+
+	i = 0
+	for range ch3 {
+		i++ // verify that the cursor continues running and eventually finishes.
+	}
+	require.Greater(t, i, 1*1024) // we see entries from the second insertion batch.
+
+	cancel()
+}
+
+func TestGrowUnderConcurrency(t *testing.T) {
+	opts := Options{ // set a really aggressive policy that makes the mmap grow very frequently.
+		InitialMmapSize:      1 << 10,
+		MmapGrowthStepFactor: 1.5,
+		MmapGrowthStepMax:    2 << 10,
+	}
+
+	bs, _ := newBlockstore(opts)(t)
+	defer bs.(io.Closer).Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ { // 20 writers.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			putEntries(t, bs, 1*1024, 1*1024)
+		}()
+	}
+
+	for i := 0; i < 20; i++ { // 20 queriers for random CIDs.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1024; i++ {
+				_, _ = bs.Get(randomCID())
+			}
+		}()
+	}
+
+	for i := 0; i < 20; i++ { // 20 deleters of random CIDs.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1024; i++ {
+				_ = bs.DeleteBlock(randomCID())
+			}
+		}()
+	}
+
+	for i := 0; i < 20; i++ { // 20 cursors.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ch, _ := bs.AllKeysChan(context.Background())
+			for range ch {
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func putEntries(t *testing.T, bs bstest.Blockstore, count int, size int) {
+	for i := 0; i < count; i++ {
+		b := make([]byte, size)
+		rand.Read(b)
+		blk := blocks.NewBlock(b)
+		err := bs.Put(blk)
+		if err != nil {
+			fmt.Println(err)
+		}
+		require.NoError(t, err)
+	}
+}
+
+func randomCID() cid.Cid {
+	b := make([]byte, 32)
+	rand.Read(b)
+	mh, _ := multihash.Encode(b, multihash.SHA2_256)
+	return cid.NewCidV1(cid.Raw, mh)
 }

--- a/blockstore_test.go
+++ b/blockstore_test.go
@@ -94,7 +94,7 @@ func TestMmapExpansionSucceedsReopen(t *testing.T) {
 	info, err = bs.(*Blockstore).env.Info()
 	require.NoError(t, err)
 	reopened := info.MapSize
-	require.EqualValues(t, 34185216, reopened) // this is the exact database size.
+	require.EqualValues(t, 34168832, reopened) // this is the exact database size.
 
 	// verify that we can add more entries, and that we grow again.
 	putEntries(t, bs, 16*1024, 1*1024)

--- a/go.mod
+++ b/go.mod
@@ -3,21 +3,22 @@ module github.com/filecoin-project/go-bs-lmdb
 go 1.15
 
 require (
-	github.com/bmatsuo/lmdb-go v1.8.0
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-datastore v0.4.5 // indirect
 	github.com/ipfs/go-ipfs-blockstore v1.0.3
 	github.com/ipfs/go-log v1.0.4 // indirect
-	github.com/ipfs/go-log/v2 v2.1.2-0.20200626104915-0016c0b4b3e4 // indirect
+	github.com/ipfs/go-log/v2 v2.1.2-0.20200626104915-0016c0b4b3e4
+	github.com/ledgerwatch/lmdb-go v1.17.4
 	github.com/minio/sha256-simd v0.1.1 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
-	github.com/multiformats/go-multihash v0.0.14 // indirect
+	github.com/multiformats/go-multihash v0.0.14
 	github.com/multiformats/go-varint v0.0.6 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/raulk/go-bs-tests v0.0.4
+	github.com/stretchr/testify v1.6.1
 	go.uber.org/zap v1.16.0 // indirect
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/bmatsuo/lmdb-go v1.8.0 h1:ohf3Q4xjXZBKh4AayUY4bb2CXuhRAI8BYGlJq08EfNA=
-github.com/bmatsuo/lmdb-go v1.8.0/go.mod h1:wWPZmKdOAZsl4qOqkowQ1aCrFie1HU8gWloHMCeAUdM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -57,6 +55,8 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/ledgerwatch/lmdb-go v1.17.4 h1:dDgPXUrzFWG/EB3RwOKZ+P3XGAlbsZxmVahjc+qWwyA=
+github.com/ledgerwatch/lmdb-go v1.17.4/go.mod h1:NKRpCxksoTQPyxsUcBiVOe0135uqnJsnf6cElxmOL0o=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=


### PR DESCRIPTION
This commit implements dynamic mmap growth. Upon an MDB_MAP_FULL error, an
mmap expansion will be attempted.

The sizing is determined by the MmapGrowthStepFactor and MmapGrowthStepMax.

* MmapGrowthStepFactor => determines the next map size when a write fails.
  The current size is multiplied by the factor, and rounded up to the next
  value divisible by os.Getpagesize(), to obtain the new map size, which is
  applied with mdb_env_set_mapsize.
* MmapGrowthStepMax => is the maximum step size by which we'll grow the mmap.

LMDB requires no transactions to be in progress when a resize takes place.
LMDB will fail if write txns are in progress, but not if there are only read txns.
Therefore, we can't rely on LMDB to correctly reject the expansion, and instead
we need to synchronize. Otherwise we risk changing the virtual address space
and keeping hanging pointers which cause segmentation faults.

Cursors are a problem, as long-running cursors can prevent expansions from
taking place entirely. Therefore, we interrupt running cursors, so that
they yield temporarily for the mmap expansion to take place. The cursor
is then resumed from the position where it was interrupted.

This commit also migrates to github.com/ledgerwatch/lmdb-go.

It also performs some cleanup and godocs enhancement.

Closes https://github.com/filecoin-project/lotus/issues/5334.