### PR TITLE
retry when readers are full; new default maxreaders: 254.

### DIFF
--- a/blockstore.go
+++ b/blockstore.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
@@ -31,6 +32,18 @@ var (
 	// used if the supplied value is zero or invalid. Unless modified, this
 	// value is 4GiB.
 	DefaultMmapGrowthStepMax = int64(4 << 30) // maximum step size is 4GiB at a time.
+
+	// DefaultMaxReaders is the default number of max readers if one is not
+	// provided. By default it is 254, not 256, following the note from the LMDB
+	// author that indicates that the original default was 126 because it fit
+	// exactly into 8KiB along with a couple of mutexes.
+	//
+	// http://www.lmdb.tech/doc/group__readers.html#gadff1f7b4d4626610a8d616e0c6dbbea4
+	DefaultMaxReaders = 254
+
+	// DefaultRetryDelay is the default retry delay for reattempting transactions
+	// that errored with MDB_READERS_FULL.
+	DefaultRetryDelay = 10 * time.Millisecond
 )
 
 var log = logging.Logger("lmdbbs")
@@ -58,8 +71,9 @@ type Blockstore struct {
 	// opts are the options for this blockstore.
 	opts *Options
 
-	pagesize int64 // the memory page size reported by the OS.
-	closed   int32
+	retryDelay time.Duration
+	pagesize   int64 // the memory page size reported by the OS.
+	closed     int32
 }
 
 var (
@@ -95,8 +109,14 @@ type Options struct {
 	// --- DB sizing fields. --- //
 
 	// MaxReaders is the maximum amount of concurrent reader slots that exist
-	// in the lock table.
+	// in the lock table. By default 254.
 	MaxReaders int
+
+	// RetryDelay is a fixed delay to wait before a transaction that errored
+	// with MDB_READERS_FULL will be reattempted. Contention due to incorrect
+	// sizing of MaxReaders will thus lead to a system slowdown via
+	// backpressure, instead of a straight out error.
+	RetryDelay time.Duration
 }
 
 func Open(opts *Options) (*Blockstore, error) {
@@ -154,11 +174,16 @@ func Open(opts *Options) (*Blockstore, error) {
 	if err = env.SetMapSize(opts.InitialMmapSize); err != nil {
 		return nil, fmt.Errorf("failed to set LMDB map size: %w", err)
 	}
-	// Use the default max readers (126) unless a value is passed in the options.
-	if opts.MaxReaders != 0 {
-		if err = env.SetMaxReaders(opts.MaxReaders); err != nil {
-			return nil, fmt.Errorf("failed to set LMDB max readers: %w", err)
-		}
+	// Use the default max readers (254) unless a value is passed in the options.
+	if opts.MaxReaders == 0 {
+		opts.MaxReaders = DefaultMaxReaders
+	}
+	if err = env.SetMaxReaders(opts.MaxReaders); err != nil {
+		return nil, fmt.Errorf("failed to set LMDB max readers: %w", err)
+	}
+	// Use a default retry delay if none is set.
+	if opts.RetryDelay == 0 {
+		opts.RetryDelay = DefaultRetryDelay
 	}
 
 	// Environment options:
@@ -237,10 +262,11 @@ func Open(opts *Options) (*Blockstore, error) {
 	}
 
 	bs := &Blockstore{
-		env:       env,
-		opts:      opts,
-		dedupGrow: new(sync.Once),
-		pagesize:  int64(pagesize),
+		env:        env,
+		opts:       opts,
+		dedupGrow:  new(sync.Once),
+		pagesize:   int64(pagesize),
+		retryDelay: opts.RetryDelay,
 	}
 	err = env.Update(func(txn *lmdb.Txn) (err error) {
 		bs.db, err = txn.OpenRoot(lmdb.Create)
@@ -284,6 +310,8 @@ func (b *Blockstore) Get(cid cid.Cid) (blocks.Block, error) {
 	defer b.oplock.RUnlock()
 
 	var val []byte
+
+Retry:
 	err := b.env.View(func(txn *lmdb.Txn) error {
 		v, err := txn.Get(b.db, cid.Hash())
 		if err == nil {
@@ -291,12 +319,19 @@ func (b *Blockstore) Get(cid cid.Cid) (blocks.Block, error) {
 		}
 		return err
 	})
+
 	switch {
 	case err == nil:
 		return blocks.NewBlockWithCid(val, cid)
 	case lmdb.IsNotFound(err) || lmdb.IsErrno(err, lmdb.BadValSize):
 		// lmdb returns badvalsize with nil keys.
 		err = blockstore.ErrNotFound
+	case lmdb.IsErrno(err, lmdb.ReadersFull):
+		b.oplock.RUnlock() // yield.
+		log.Warnf("get encountered MDB_READERS_FULL; waiting %s", b.retryDelay)
+		time.Sleep(b.retryDelay)
+		b.oplock.RLock()
+		goto Retry
 	}
 	return nil, err
 }
@@ -305,6 +340,7 @@ func (b *Blockstore) View(cid cid.Cid, callback func([]byte) error) error {
 	b.oplock.RLock()
 	defer b.oplock.RUnlock()
 
+Retry:
 	err := b.env.View(func(txn *lmdb.Txn) error {
 		txn.RawRead = true
 		v, err := txn.Get(b.db, cid.Hash())
@@ -314,11 +350,16 @@ func (b *Blockstore) View(cid cid.Cid, callback func([]byte) error) error {
 		return err
 	})
 	switch {
-	case err == nil:
-		return nil // shortcircuit the happy path with no comparisons.
+	case err == nil: // shortcircuit the happy path with no comparisons.
 	case lmdb.IsNotFound(err) || lmdb.IsErrno(err, lmdb.BadValSize):
 		// lmdb returns badvalsize with nil keys.
 		err = blockstore.ErrNotFound
+	case lmdb.IsErrno(err, lmdb.ReadersFull):
+		b.oplock.RUnlock() // yield.
+		log.Warnf("view encountered MDB_READERS_FULL; waiting %s", b.retryDelay)
+		time.Sleep(b.retryDelay)
+		b.oplock.RLock()
+		goto Retry
 	}
 	return err
 }
@@ -327,6 +368,7 @@ func (b *Blockstore) GetSize(cid cid.Cid) (int, error) {
 	b.oplock.RLock()
 	defer b.oplock.RUnlock()
 
+Retry:
 	size := -1
 	err := b.env.View(func(txn *lmdb.Txn) error {
 		txn.RawRead = true
@@ -336,12 +378,19 @@ func (b *Blockstore) GetSize(cid cid.Cid) (int, error) {
 		}
 		return err
 	})
+
 	switch {
-	case err == nil:
-		return size, nil // shortcircuit the happy path with no comparisons.
+	case err == nil: // shortcircuit happy path.
 	case lmdb.IsNotFound(err) || lmdb.IsErrno(err, lmdb.BadValSize):
 		err = blockstore.ErrNotFound
+	case lmdb.IsErrno(err, lmdb.ReadersFull):
+		b.oplock.RUnlock() // yield.
+		log.Warnf("get size encountered MDB_READERS_FULL; waiting %s", b.retryDelay)
+		time.Sleep(b.retryDelay)
+		b.oplock.RLock()
+		goto Retry
 	}
+
 	return size, err
 }
 
@@ -357,7 +406,10 @@ Retry:
 		}
 		return err
 	})
-	if lmdb.IsMapFull(err) {
+
+	switch {
+	case err == nil: // shortcircuit happy path.
+	case lmdb.IsMapFull(err):
 		o := b.dedupGrow   // take the deduplicator under the lock.
 		b.oplock.RUnlock() // drop the concurrent lock.
 		var err error
@@ -367,7 +419,14 @@ Retry:
 		}
 		b.oplock.RLock() // reclaim the concurrent lock.
 		goto Retry
+	case lmdb.IsErrno(err, lmdb.ReadersFull):
+		b.oplock.RUnlock() // yield.
+		log.Warnf("put encountered MDB_READERS_FULL; waiting %s", b.retryDelay)
+		time.Sleep(b.retryDelay)
+		b.oplock.RLock()
+		goto Retry
 	}
+
 	return err
 }
 
@@ -386,7 +445,10 @@ Retry:
 		}
 		return nil
 	})
-	if lmdb.IsMapFull(err) {
+
+	switch {
+	case err == nil: // shortcircuit happy path.
+	case lmdb.IsMapFull(err):
 		o := b.dedupGrow   // take the deduplicator under the lock.
 		b.oplock.RUnlock() // drop the concurrent lock.
 		var err error
@@ -396,7 +458,14 @@ Retry:
 		}
 		b.oplock.RLock() // reclaim the concurrent lock.
 		goto Retry
+	case lmdb.IsErrno(err, lmdb.ReadersFull):
+		b.oplock.RUnlock() // yield.
+		log.Warnf("put many encountered MDB_READERS_FULL; waiting %s", b.retryDelay)
+		time.Sleep(b.retryDelay)
+		b.oplock.RLock()
+		goto Retry
 	}
+
 	return err
 }
 
@@ -408,10 +477,10 @@ Retry:
 	err := b.env.Update(func(txn *lmdb.Txn) error {
 		return txn.Del(b.db, cid.Hash(), nil)
 	})
-	if lmdb.IsNotFound(err) {
+	switch {
+	case err == nil || lmdb.IsNotFound(err): // shortcircuit happy path.
 		return nil
-	}
-	if lmdb.IsMapFull(err) {
+	case lmdb.IsMapFull(err):
 		o := b.dedupGrow   // take the deduplicator under the lock.
 		b.oplock.RUnlock() // drop the concurrent lock.
 		var err error
@@ -420,6 +489,12 @@ Retry:
 			return fmt.Errorf("lmbd delete failed: %w", err)
 		}
 		b.oplock.RLock() // reclaim the concurrent lock.
+		goto Retry
+	case lmdb.IsErrno(err, lmdb.ReadersFull):
+		b.oplock.RUnlock() // yield.
+		log.Warnf("delete encountered MDB_READERS_FULL; waiting %s", b.retryDelay)
+		time.Sleep(b.retryDelay)
+		b.oplock.RLock()
 		goto Retry
 	}
 	return err
@@ -462,6 +537,7 @@ func (c *cursor) run() {
 	default:
 	}
 
+Retry:
 	var notifyClosed chan struct{}
 	err := c.b.env.View(func(txn *lmdb.Txn) error {
 		txn.RawRead = true
@@ -499,11 +575,19 @@ func (c *cursor) run() {
 			case c.outCh <- it:
 			case notifyClosed = <-c.interruptCh:
 				return errInterrupted
+			case <-c.ctx.Done():
+				return nil
 			}
 			c.last = it
 		}
 		return nil
 	})
+
+	if lmdb.IsErrno(err, lmdb.ReadersFull) {
+		log.Warnf("cursor encountered MDB_READERS_FULL; waiting %s", c.b.retryDelay)
+		time.Sleep(c.b.retryDelay)
+		goto Retry
+	}
 
 	if err == errInterrupted {
 		close(notifyClosed)


### PR DESCRIPTION
All operations will now retry if they receive an `MDB_READERS_FULL` error. This translates contention into backpressure that makes the system slow down, but not fail entirely.

This commit also fixes the cursor not immediately aborting when the context is cancelled while sending to the consumer.